### PR TITLE
inputのフォントサイズ指定に"px"をつけた

### DIFF
--- a/Assets/WebGLSupport/WebGLInput/WebGLInput.jslib
+++ b/Assets/WebGLSupport/WebGLInput/WebGLInput.jslib
@@ -17,7 +17,7 @@ var WebGLInput = {
 		input.style.cursor = "default";
 		input.spellcheck = false;
 		input.value = Pointer_stringify(text);
-		input.style.fontSize = fontsize;
+		input.style.fontSize = fontsize + "px";
 		input.setSelectionRange(0, input.value.length);
 		
 		if(isPassword){


### PR DESCRIPTION
"px"をつけることで､正常にサイズが指定できました
透明で見えないInputですが､16px未満のフォントサイズの場合
携帯のブラウザでズームがかかってしまうため
それなりに意味があると思っています