### PR TITLE
Fixed cursor being one character behind if changing input text from code

### DIFF
--- a/Assets/WebGLSupport/WebGLInput/WebGLInput.cs
+++ b/Assets/WebGLSupport/WebGLInput/WebGLInput.cs
@@ -298,7 +298,7 @@ namespace WebGLSupport
             if (value != instance.input.text)
             {
                 WebGLInputPlugin.WebGLInputText(id, instance.input.text);
-                WebGLInputPlugin.WebGLInputSetSelectionRange(id, index, index);
+                WebGLInputPlugin.WebGLInputSetSelectionRange(id, index+1, index+1);
             }
         }
         [MonoPInvokeCallback(typeof(Action<int, string>))]


### PR DESCRIPTION
Fix for a bug, when changing the `text` property from a script

Expected:
Cursor will stay in the same position

Actual:
Cursor moves back one position

Repro:
Create a TMP Input, give it the WebGLInput.cs component. Create a script that listens for the input's OnValueChanged, have the script, for example, change the text to all uppercase. Test in a WebGL build.

```
public void OnInputValueChanged()
{
        input.text = input.text.ToUpper();
}
```
