### PR TITLE
WebGLTemplate : minimal 使う場合の例外対応

### DIFF
--- a/Assets/WebGLSupport/WebGLWindow/WebGLWindow.jslib
+++ b/Assets/WebGLSupport/WebGLWindow/WebGLWindow.jslib
@@ -6,7 +6,16 @@ var WebGLWindow = {
 	},
     WebGLWindowGetCanvasName: function() {
         var elements = document.getElementsByTagName('canvas');
-        var returnStr = (elements.length <= 0) ? "" : elements[0].parentNode.id;
+        var returnStr = "";
+        if(elements.length >= 1)
+        {
+            returnStr = elements[0].parentNode.id;
+            // workaround : for WebGLTemplate:Minimal temp! body element not have id!
+            if(returnStr == '')
+            {
+                returnStr = elements[0].parentNode.id = 'WebGLWindow:Canvas:ParentNode';
+            }
+        }
 		var bufferSize = lengthBytesUTF8(returnStr) + 1;
 		var buffer = _malloc(bufferSize);
 		stringToUTF8(returnStr, buffer, bufferSize);


### PR DESCRIPTION
WebGLTemplate : minimal を使用する場合、
canvas の親要素がid 指定されてなくて空き文字列を取得され、
実際アクセス時に空き文字列で要素検索して失敗してしまったため対策

・canvasの親要素のid が空白の場合、決め打ちで id を付与するようにします