### PR TITLE
fix error for unity 2022

### DIFF
--- a/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedUIToolkit.cs
+++ b/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedUIToolkit.cs
@@ -22,7 +22,11 @@ namespace WebGLSupport
         {
             get
             {
+#if UNITY_2023_1_OR_NEWER
                 return input.textEdition.placeholder;
+#else
+                return "";
+#endif
             }
         }
 


### PR DESCRIPTION
TextField not have placeholder. placeholder is from unity 2023