### PR TITLE
Fix: Release event listeners for WebGLWindow to prevent page hang dur…

### DIFF
--- a/Assets/WebGLSupport/WebGLWindow/WebGLWindow.cs
+++ b/Assets/WebGLSupport/WebGLWindow/WebGLWindow.cs
@@ -11,6 +11,9 @@ namespace WebGLSupport
         [DllImport("__Internal")]
         public static extern void WebGLWindowInit();
         [DllImport("__Internal")]
+        public static extern void WebGLWindowUninit();
+
+        [DllImport("__Internal")]
         public static extern void WebGLWindowOnFocus(Action cb);
 
         [DllImport("__Internal")]
@@ -35,6 +38,7 @@ namespace WebGLSupport
         public static extern bool IsFullscreen();
 #else
         public static void WebGLWindowInit() { }
+        public static void WebGLWindowUninit() { }
         public static void WebGLWindowOnFocus(Action cb) { }
         public static void WebGLWindowOnBlur(Action cb) { }
         public static void WebGLWindowOnResize(Action cb) { }
@@ -66,6 +70,13 @@ namespace WebGLSupport
             WebGLWindowPlugin.WebGLWindowOnBlur(OnWindowBlur);
             WebGLWindowPlugin.WebGLWindowOnResize(OnWindowResize);
             WebGLWindowPlugin.WebGLWindowInjectFullscreen();
+
+            Application.quitting += Uninit;
+        }
+        static void Uninit()
+        {
+            WebGLWindowPlugin.WebGLWindowUninit();
+            Application.quitting -= Uninit;
         }
 
         [MonoPInvokeCallback(typeof(Action))]

--- a/Assets/WebGLSupport/WebGLWindow/WebGLWindow.jslib
+++ b/Assets/WebGLSupport/WebGLWindow/WebGLWindow.jslib
@@ -1,4 +1,8 @@
 var WebGLWindow = {
+    focusListener: null,
+    blurListener: null,
+    resizeListener: null,
+    
     WebGLWindowInit : function() {
         // use WebAssembly.Table : makeDynCall
         // when enable. dynCall is undefined
@@ -14,6 +18,21 @@ var WebGLWindow = {
             if(typeof Runtime === "undefined") Runtime = { dynCall : dynCall }
         }
     },
+    WebGLWindowUninit : function() {
+        if(focusListener) {
+            window.removeEventListener('focus', this.focusListener);
+            this.focusListener = null;
+        }
+        if(blurListener) {
+            window.removeEventListener('blur', this.blurListener);
+            this.blurListener = null;
+        }
+        if(resizeListener) {
+            window.removeEventListener('resize', this.resizeListener);
+            this.resizeListener = null;
+        }
+    },
+
     WebGLWindowGetCanvasName: function() {
         var elements = document.getElementsByTagName('canvas');
         var returnStr = "";
@@ -32,19 +51,22 @@ var WebGLWindow = {
         return buffer;
     },
     WebGLWindowOnFocus: function (cb) {
-        window.addEventListener('focus', function () {
-            (!!Runtime.dynCall) ? Runtime.dynCall("v", cb, []) : {{{ makeDynCall("v", "cb") }}}();
-        });
+        this.focusListener = function () { 
+            (!!Runtime.dynCall) ? Runtime.dynCall("v", cb, []) : {{{ makeDynCall("v", "cb") }}}(); 
+        };
+        window.addEventListener('focus', this.focusListener);
     },
     WebGLWindowOnBlur: function (cb) {
-        window.addEventListener('blur', function () {
-            (!!Runtime.dynCall) ? Runtime.dynCall("v", cb, []) : {{{ makeDynCall("v", "cb") }}}();
-        });
+        this.blurListener = function () { 
+            (!!Runtime.dynCall) ? Runtime.dynCall("v", cb, []) : {{{ makeDynCall("v", "cb") }}}(); 
+        };
+        window.addEventListener('blur', this.blurListener);
     },
     WebGLWindowOnResize: function(cb) {
-        window.addEventListener('resize', function () {
-            (!!Runtime.dynCall) ? Runtime.dynCall("v", cb, []) : {{{ makeDynCall("v", "cb") }}}();
-        });
+        this.resizeListener = function () { 
+            (!!Runtime.dynCall) ? Runtime.dynCall("v", cb, []) : {{{ makeDynCall("v", "cb") }}}(); 
+        };
+        window.addEventListener('resize', this.resizeListener);
     },
     WebGLWindowInjectFullscreen : function () {
         document.makeFullscreen = function (id, keepAspectRatio) {


### PR DESCRIPTION
* Fixed an issue where WebGLWindow event listeners (such as focus, blur, and resize) were not properly removed.
* This issue caused the page to freeze when navigating away or going back, as the listeners were still active and blocking the process.
* Now ensures that event listeners are correctly cleaned up during page unload.