### PR TITLE
Fix caret movement

### DIFF
--- a/Assets/WebGLSupport/WebGLInput/Events/KeyboardEvent.cs
+++ b/Assets/WebGLSupport/WebGLInput/Events/KeyboardEvent.cs
@@ -1,15 +1,22 @@
+/* 
+ * Copyright (c) 2025 Hancom, Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
 namespace WebGLSupport
 {
     public delegate void KeyboardEventHandler(WebGLInput input, KeyboardEvent keyboardEvent);
     public sealed class KeyboardEvent
     {
+        public int Id { get; }
         public string Key { get; }
         public int Code { get; }
         public bool ShiftKey { get; }
         public bool CtrlKey { get; }
         public bool AltKey { get; }
-        public KeyboardEvent(string key, int code, bool shiftKey, bool ctrlKey, bool altKey)
+        public KeyboardEvent(int id, string key, int code, bool shiftKey, bool ctrlKey, bool altKey)
         {
+            Id = id;
             Key = key;
             Code = code;
             ShiftKey = shiftKey;

--- a/Assets/WebGLSupport/WebGLInput/WebGLInput.cs
+++ b/Assets/WebGLSupport/WebGLInput/WebGLInput.cs
@@ -27,6 +27,9 @@ namespace WebGLSupport
         public static extern int WebGLInputCreate(string canvasId, int x, int y, int width, int height, int fontsize, string text, string placeholder, bool isMultiLine, bool isPassword, bool isHidden, bool isMobile);
 
         [DllImport("__Internal")]
+        public static extern void WebGLInputEscape(int id);
+
+        [DllImport("__Internal")]
         public static extern void WebGLInputEnterSubmit(int id, bool flag);
 
         [DllImport("__Internal")]
@@ -84,6 +87,7 @@ namespace WebGLSupport
 #else
         public static void WebGLInputInit() { }
         public static int WebGLInputCreate(string canvasId, int x, int y, int width, int height, int fontsize, string text, string placeholder, bool isMultiLine, bool isPassword, bool isHidden, bool isMobile) { return 0; }
+        public static void WebGLInputEscape(int id) { }
         public static void WebGLInputEnterSubmit(int id, bool flag) { }
         public static void WebGLInputTab(int id, Action<int, int> cb) { }
         public static void WebGLInputFocus(int id) { }
@@ -208,6 +212,7 @@ namespace WebGLSupport
             id = WebGLInputPlugin.WebGLInputCreate(WebGLInput.CanvasId, rect.x, rect.y, rect.width, rect.height, fontSize, input.text, input.placeholder, input.lineType != LineType.SingleLine, isPassword, isHidden, Application.isMobilePlatform);
 
             instances[id] = this;
+            WebGLInputPlugin.WebGLInputEscape(id);
             WebGLInputPlugin.WebGLInputEnterSubmit(id, input.lineType != LineType.MultiLineNewline);
             WebGLInputPlugin.WebGLInputOnFocus(id, OnFocus);
             WebGLInputPlugin.WebGLInputOnBlur(id, OnBlur);

--- a/Assets/WebGLSupport/WebGLInput/WebGLInput.jslib
+++ b/Assets/WebGLSupport/WebGLInput/WebGLInput.jslib
@@ -1,3 +1,8 @@
+/* 
+ * Copyright (c) 2025 Hancom, Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
 var WebGLInput = {
     $instances: [],
     WebGLInputInit : function() {
@@ -74,6 +79,10 @@ var WebGLInput = {
         
         if(isPassword){
             input.type = 'password';
+        }
+
+        if(isHidden){
+            input.style.pointerEvents = 'none';
         }
 
         if(isMobile) {

--- a/Assets/WebGLSupport/WebGLInput/WebGLInput.jslib
+++ b/Assets/WebGLSupport/WebGLInput/WebGLInput.jslib
@@ -92,6 +92,15 @@ var WebGLInput = {
         }
         return instances.push(input) - 1;
     },
+    WebGLInputEscape: function (id) {
+        var input = instances[id];
+        input.addEventListener('keydown', function (e) {
+            if ((e.which && e.which === 27) || (e.keyCode && e.keyCode === 27)) {
+                e.preventDefault();
+                input.blur();
+            }
+        });
+    },
     WebGLInputEnterSubmit: function(id, falg){
         var input = instances[id];
         // for enter key

--- a/Assets/WebGLSupport/WebGLInput/Wrapper/IInputField.cs
+++ b/Assets/WebGLSupport/WebGLInput/Wrapper/IInputField.cs
@@ -1,4 +1,9 @@
-﻿using UnityEngine;
+﻿/* 
+ * Copyright (c) 2025 Hancom, Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+using UnityEngine;
 
 namespace WebGLSupport
 {
@@ -41,6 +46,7 @@ namespace WebGLSupport
 
         void ActivateInputField();
         void DeactivateInputField();
+        void CreateKeyEvent(Event e);
         void Rebuild();
     }
 }

--- a/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedInputField.cs
+++ b/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedInputField.cs
@@ -1,4 +1,9 @@
-﻿using UnityEngine;
+﻿/* 
+ * Copyright (c) 2025 Hancom, Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+using UnityEngine;
 using UnityEngine.UI;
 using WebGLSupport.Detail;
 
@@ -100,6 +105,11 @@ namespace WebGLSupport
         public void DeactivateInputField()
         {
             input.DeactivateInputField();
+        }
+
+        public void CreateKeyEvent(Event e)
+        {
+            input.ProcessEvent(e);
         }
 
         public void Rebuild()

--- a/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedTMPInputField.cs
+++ b/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedTMPInputField.cs
@@ -1,4 +1,9 @@
-﻿#if UNITY_2018_2_OR_NEWER
+﻿/* 
+ * Copyright (c) 2025 Hancom, Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+#if UNITY_2018_2_OR_NEWER
 #define TMP_WEBGL_SUPPORT
 #endif
 
@@ -151,6 +156,11 @@ namespace WebGLSupport
         public void DeactivateInputField()
         {
             input.DeactivateInputField();
+        }
+
+        public void CreateKeyEvent(Event e)
+        {
+            input.ProcessEvent(e);
         }
 
         public void Rebuild()

--- a/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedUIToolkit.cs
+++ b/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedUIToolkit.cs
@@ -1,4 +1,9 @@
-﻿using UnityEngine;
+﻿/* 
+ * Copyright (c) 2025 Hancom, Inc.
+ * SPDX-License-Identifier: MIT
+ */
+
+using UnityEngine;
 using UnityEngine.UIElements;
 
 namespace WebGLSupport
@@ -153,6 +158,10 @@ namespace WebGLSupport
         public void DeactivateInputField()
         {
             input.Blur();
+        }
+
+        public void CreateKeyEvent(Event e)
+        {
         }
 
         public void Rebuild()


### PR DESCRIPTION
### Now we can
- Select and drag text within an Input Field using the mouse.
- Deselect an Input Field by pressing the ESC key.
  + tested only with TMP_InputField
- Navigate the caret using the up and down arrow keys.

### Note
- May not apply fully to UI Toolkit and InputField (legacy)