### PR TITLE
Add Clear and ClearAll methods to WebGLInput

### DIFF
--- a/Assets/WebGLSupport/WebGLInput/WebGLInput.cs
+++ b/Assets/WebGLSupport/WebGLInput/WebGLInput.cs
@@ -526,6 +526,38 @@ namespace WebGLSupport
         }
 
         /// <summary>
+        /// Clear this input field text completely.
+        /// (Both unity and HTML sides)
+        /// </summary>
+        public void Clear()
+        {
+            // Clear Unity side
+            if (input != null)
+            {
+                input.text = string.Empty;
+            }
+
+            // Clear HTML element if exists
+            if (instances.ContainsKey(id))
+            {
+                WebGLInputPlugin.WebGLInputText(id, string.Empty);
+            }
+        }
+
+
+        /// <summary>
+        /// Clear all HTML input elements and Unity input fields.
+        /// Ensures both Unity and HTML sides are cleared.
+        /// </summary>
+        public static void ClearAll()
+        {
+            foreach (var instance in instances.Values)
+            {
+                instance.Clear();
+            }
+        }
+
+        /// <summary>
         /// to manage tab focus
         /// base on scene position
         /// </summary>


### PR DESCRIPTION
**Summary**
Implemented two new methods for input field management.
- Clear() — Resets the text content of a single input field on both Unity and HTML sides.
- ClearAll() — Clears all input fields simultaneously.

**Details**
These methods provide a programmatic way to reset input fields, ensuring that users start with a clean state when entering new data. Without invoking these methods, previously entered text values may persist across sessions and unintentionally override new inputs. 