### PR TITLE
Handle TMP_InputField Regex character validation mapping to prevent enum parse exception

### DIFF
--- a/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedTMPInputField.cs
+++ b/Assets/WebGLSupport/WebGLInput/Wrapper/WrappedTMPInputField.cs
@@ -44,7 +44,19 @@ namespace WebGLSupport
             i.lineType = (InputField.LineType)Enum.Parse(typeof(InputField.LineType), input.lineType.ToString());
             i.inputType = (InputField.InputType)Enum.Parse(typeof(InputField.InputType), input.inputType.ToString());
             i.keyboardType = input.keyboardType;
-            i.characterValidation = (InputField.CharacterValidation)Enum.Parse(typeof(InputField.CharacterValidation), input.characterValidation.ToString());
+            
+            // Fix: Only map known values, fallback for Regex
+            var charValidationStr = input.characterValidation.ToString();
+            if (Enum.IsDefined(typeof(InputField.CharacterValidation), charValidationStr))
+            {
+                i.characterValidation = (InputField.CharacterValidation)Enum.Parse(typeof(InputField.CharacterValidation), charValidationStr);
+            }
+            else
+            {
+                // Fallback to None or another appropriate value
+                i.characterValidation = InputField.CharacterValidation.None;
+            }
+            
             i.characterLimit = input.characterLimit;
             i.text = inText;
             var res = i.text;


### PR DESCRIPTION
This PR fixes [Issue #185](https://github.com/kou-yeung/WebGLInput/issues/185) by adding a check to ensure only supported enum values are mapped, and fallback to a default value (e.g., None) for unsupported values like Regex.

Details of the underlying issue:

**Description:**
When using a `TMP_InputField` with `ContentType` set to `Custom` and `characterValidation` set to `Regex`, the WebGLInput wrapper attempts to map the TMP enum value to the standard `InputField.CharacterValidation` enum. Since `Regex` is not defined in the standard enum, this results in a `System.ArgumentException`:
> Requested value 'Regex' was not found.

**Steps to Reproduce:**
1. Create a TMP_InputField in Unity.
2. Set ContentType to Custom.
3. Set characterValidation to Regex.
4. Attempt to set the input field value via the WebGLInput wrapper.

**Expected Behavior:**
Setting the value should not throw an exception.

**Actual Behavior:**
An exception is thrown due to an unsupported enum value mapping.

**Suggested Fix:**
Add a check to ensure only supported enum values are mapped, and fallback to a default value (e.g., None) for unsupported values like Regex.